### PR TITLE
PHP warning fix, new default template method, autoloading js/css

### DIFF
--- a/config/autoload.php
+++ b/config/autoload.php
@@ -1,4 +1,5 @@
 <?php
 
 # Load the template library when the spark is loaded
+$autoload['config'] = array('template');
 $autoload['libraries'] = array('template');

--- a/config/template.php
+++ b/config/template.php
@@ -14,9 +14,11 @@ $config['parser']    = FALSE;
 $config['template']  = 'template';
 $config['cache_ttl'] = 0;
 
+$config['widget_path'] = APPPATH . 'widgets/';
+
 $config['autoload_view_css'] = FALSE;
-$config['autoload_view_css_path'] = 'assets/css/views/';
+$config['autoload_view_css_path'] = FCPATH . 'assets/css/views/';
 
 $config['autoload_view_js'] = FALSE;
-$config['autoload_view_js_path'] = 'assets/js/views/';
+$config['autoload_view_js_path'] = FCPATH . 'assets/js/views/';
 

--- a/config/template.php
+++ b/config/template.php
@@ -13,3 +13,10 @@
 $config['parser']    = FALSE;
 $config['template']  = 'template';
 $config['cache_ttl'] = 0;
+
+$config['autoload_view_css'] = FALSE;
+$config['autoload_view_css_path'] = 'assets/css/views/';
+
+$config['autoload_view_js'] = FALSE;
+$config['autoload_view_js_path'] = 'assets/js/views/';
+

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -591,8 +591,6 @@ class Partial {
             return implode('', $args);
         } else {
         	
-			$this->_ci->console->log($args);
-			
             return call_user_func_array($this->_trigger, $args);
         }
     }
@@ -619,7 +617,7 @@ class Partial {
                 $this->_trigger = array($obj, $func);
             } else {
                 	
-                $args = reset($args);
+                $this->_trigger = reset($args);
             }
         } else {
             $this->_trigger = FALSE;

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -405,6 +405,8 @@ class Partial {
         $this->_ci = &get_instance();
         $this->_args = $args;
         $this->_name = $name;
+		
+		$this->_content = FALSE;
     }
     
     /**
@@ -499,7 +501,7 @@ class Partial {
      */
     public function set_default($default) {
         if (!$this->_cached) {
-            if (!$this->_content) {
+            if ($this->_content === FALSE) {
                 $this->_content = $default;
             }
         }
@@ -511,7 +513,7 @@ class Partial {
 		
 		if (!$this->_cached) {
             
-			if (!$this->_content) {
+			if ($this->_content === FALSE) {
 				            
 				if ($parse){
 					

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -112,7 +112,7 @@ class Template {
      * @param string $template
      * @param array $data
      */
-    public function publish($template = FALSE, $data = array()) {
+    public function publish($template = FALSE, $data = array(), $return = FALSE) {
         if (is_array($template) || is_object($template)) {
             $data = $template;
         } else if ($template) {
@@ -169,9 +169,9 @@ class Template {
 
         
         if ($this->_parser) {
-            $this->_ci->parser->parse($this->_template, $this->_partials);
+            $this->_ci->parser->parse($this->_template, $this->_partials, $return);
         } else {
-            $this->_ci->load->view($this->_template, $this->_partials);
+            $this->_ci->load->view($this->_template, $this->_partials, $return);
         }
     }
     

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -362,6 +362,9 @@ class Partial {
             case 'default' :
                 return call_user_func_array(array($this, 'set_default'), $args);
                 break;
+			case 'default_view' :
+                return call_user_func_array(array($this, 'set_default_view'), $args);
+                break;
             case 'add' :
                 return call_user_func_array(array($this, 'append'), $args);
                 break;
@@ -442,22 +445,20 @@ class Partial {
         return $this;
     }
 	
-	public function set_default_view($view, $data){
+	public function set_default_view($view, $data = array(), $parse = FALSE){
 		
 		if (!$this->_cached) {
             
 			if (!$this->_content) {
-			
-	            // better object to array
-	            if (is_object($data)) {
-	                $array = array();
-	                foreach ($data as $k => $v) {
-	                    $array[$k] = $v;
-	                }
-	                $data = $array;
-	            }
-	            
-	            $this->set($this->_ci->load->view($view, $data, true));              
+				            
+				if ($parse){
+					
+					$this->parse($view, $data, TRUE);
+				}
+				else {
+					
+					$this->view($view, $data, TRUE);
+				}	          
 			}
         }
 		

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -441,6 +441,28 @@ class Partial {
         
         return $this;
     }
+	
+	public function set_default_view($view, $data){
+		
+		if (!$this->_cached) {
+            
+			if (!$this->_content) {
+			
+	            // better object to array
+	            if (is_object($data)) {
+	                $array = array();
+	                foreach ($data as $k => $v) {
+	                    $array[$k] = $v;
+	                }
+	                $data = $array;
+	            }
+	            
+	            $this->set($this->_ci->load->view($view, $data, true));              
+			}
+        }
+		
+        return $this;
+	}
     
     /**
      * Load a view inside this partial, overwrite if wanted

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -45,9 +45,6 @@ class Template {
     public function __construct($config = array()) {
         $this->_ci = & get_instance();
         
-        // set the default widget path with APPPATH
-        $this->_widget_path = APPPATH . 'widgets/';
-        
         if (!empty($config)) {
             $this->initialize($config);
         }
@@ -203,7 +200,7 @@ class Template {
             $this->_partials[$name] = $partial;
         }
         
-        if (!$partial->content() && $default) {
+        if ($partial->content() === FALSE && $default !== FALSE) {
             $partial->set($default);
         }
         

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -34,6 +34,12 @@ class Template {
     private $_parser = FALSE;
     private $_cache_ttl = 0;
     private $_widget_path = '';
+	
+	private $_autoload_view_css = FALSE;
+	private $_autoload_view_css_path = '';
+	
+	private $_autoload_view_js = FALSE;
+	private $_autoload_view_js_path = '';
     
     private $_ci;
     private $_partials = array();
@@ -156,9 +162,9 @@ class Template {
 				
 			foreach($this->_partials as $partial){
 				
-				if ($partial->_views){
+				if ($views = $partial->get_views()){
 					
-					foreach($partial->_views as $view){
+					foreach($views as $view){
 						
 						if ($this->_autoload_view_css){
 			
@@ -432,8 +438,13 @@ class Partial {
      * @param string $index
      */
     function __get($name) {
-        return $name == '_views' ? $this->_views : $this->_ci->$name;
+        return $this->_ci->$name;
     }
+	
+	function get_views(){
+		
+		return $this->_views();
+	}
     
     /**
      * Alias methods
@@ -592,8 +603,6 @@ class Partial {
      * @return Partial
      */
     public function parse($view, $data = array(), $overwrite = false) {
-        
-		$this->autoload_view_assets($view);	
 			
         if (!$this->_cached) {
             if (!class_exists('CI_Parser')) {

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -589,7 +589,7 @@ class Partial {
                 
                 $this->_trigger = array($obj, $func);
             } else {
-                $this->_trigger = reset(func_get_args());
+                $this->_trigger = func_get_args();
             }
         } else {
             $this->_trigger = FALSE;

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -69,6 +69,8 @@ class Template {
         if ($this->_parser && !class_exists('CI_Parser')) {
             $this->_ci->load->library('parser');
         }
+		
+		return $this;
     }
     
     /**
@@ -105,6 +107,15 @@ class Template {
     public function set_template($template) {
         $this->_template = $template;
     }
+	
+	/*
+	 * Returns an array of all the templates partials
+	 * @return partial array
+	 */
+	public function get_partials(){
+		
+		return $this->_partials;
+	}
     
     /**
      * Publish the template with the current partials

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -147,11 +147,10 @@ class Template {
 			
 							$css_file = $this->_autoload_view_css_path . $view . '.css';
 							
-							
-				
+								
 							//try to load css and js with same name
 							if (file_exists($css_file)){
-								$this->_ci->console->log(file_get_contents($css_file));
+
 								$this->stylesheet->add(file_get_contents($css_file), FALSE, TRUE);
 							}
 						}

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -590,6 +590,9 @@ class Partial {
         if (!$this->_trigger) {
             return implode('', $args);
         } else {
+        	
+			$this->_ci->console->log($args);
+			
             return call_user_func_array($this->_trigger, $args);
         }
     }
@@ -601,8 +604,11 @@ class Partial {
      */
     public function bind() {
         if ($count = func_num_args()) {
+        	
+            $args = func_get_args();
+				
             if ($count >= 2) {
-                $args = func_get_args();
+                
                 $obj = array_shift($args);
                 $func = array_pop($args);
                 
@@ -612,7 +618,8 @@ class Partial {
                 
                 $this->_trigger = array($obj, $func);
             } else {
-                $this->_trigger = func_get_args();
+                	
+                $args = reset($args);
             }
         } else {
             $this->_trigger = FALSE;

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -109,6 +109,15 @@ class Template {
     }
 	
 	/*
+	 * Returns the currently set template.
+	 * return string template
+	 */
+	public function get_template(){
+		
+		return $this->_template;
+	}
+	
+	/*
 	 * Returns an array of all the templates partials
 	 * @return partial array
 	 */

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -189,9 +189,9 @@ class Template {
 
         
         if ($this->_parser) {
-            $this->_ci->parser->parse($this->_template, $this->_partials, $return);
+            return $this->_ci->parser->parse($this->_template, $this->_partials, $return);
         } else {
-            $this->_ci->load->view($this->_template, $this->_partials, $return);
+            return $this->_ci->load->view($this->_template, $this->_partials, $return);
         }
     }
     


### PR DESCRIPTION
None of my modifications/additions are breaking changes. To use the autoloading feature, you specify the path to your assets folder that mirrors your views folder. If a stylesheet or js file is present with the same name as the view file in the corresponding folder, it is auto loaded if this feature is turned on in the configuration. 
